### PR TITLE
Add news mechanic and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import sys
 import streamlit as st
 
 from mechanics.calendar_mechanics import CalendarMechanics
+from mechanics.news_mechanics import NewsMechanics
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -16,7 +17,14 @@ def main():
 
     st.sidebar.title("🧪 Testes")
     st.sidebar.markdown("---")
-    tab_names = ["📅 Calendário", "💰 Mercado Financeiro", "🧪 Testes de Mesa", "📊 Comparação", "ℹ️ Sobre"]
+    tab_names = [
+        "📅 Calendário",
+        "💰 Mercado Financeiro",
+        "📰 Eventos",
+        "🧪 Testes de Mesa",
+        "📊 Comparação",
+        "ℹ️ Sobre",
+    ]
     selected_tab = st.sidebar.selectbox("Escolha uma seção:", tab_names)
   
     if selected_tab == "📅 Calendário":
@@ -31,6 +39,10 @@ def main():
         st.title(selected_tab)
         st.markdown("Este é um teste de conceito para o mercado financeiro.")
         st.write("Aqui você pode adicionar funcionalidades relacionadas ao mercado financeiro.")
+    elif selected_tab == "📰 Eventos":
+        st.title(selected_tab)
+        news_mechanics = NewsMechanics()
+        news_mechanics.run()
     elif selected_tab == "🧪 Testes de Mesa":
         st.title(selected_tab)
         st.markdown("Este é um teste de conceito para testes de mesa.")

--- a/mechanics/news_mechanics.py
+++ b/mechanics/news_mechanics.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+import random
+import streamlit as st
+
+@dataclass
+class NewsEvent:
+    name: str
+    price_modifier: float = 1.0
+    demand_modifier: float = 1.0
+    availability_modifier: float = 1.0
+    duration: int = 1
+
+
+class NewsMechanics:
+    """Simple system for random news events affecting market variables."""
+
+    def __init__(self):
+        self.events = [
+            NewsEvent("Black Friday", price_modifier=0.8, demand_modifier=1.5, availability_modifier=1.2, duration=3),
+            NewsEvent("Greve de Transportes", price_modifier=1.1, demand_modifier=0.9, availability_modifier=0.5, duration=5),
+            NewsEvent("Lançamento de Produto", price_modifier=1.0, demand_modifier=1.3, availability_modifier=1.0, duration=2),
+        ]
+
+    def generate_event(self, name: str | None = None) -> NewsEvent:
+        """Return a random event or one by name."""
+        if name:
+            for event in self.events:
+                if event.name == name:
+                    return event
+        return random.choice(self.events)
+
+    def apply_modifiers(self, base_values: dict, event: NewsEvent) -> dict:
+        """Apply event modifiers to a dict with price, demand and availability."""
+        return {
+            "price": base_values.get("price", 0) * event.price_modifier,
+            "demand": base_values.get("demand", 0) * event.demand_modifier,
+            "availability": base_values.get("availability", 0) * event.availability_modifier,
+        }
+
+    def run(self):
+        """Display interface to generate and apply news events."""
+        st.markdown("### 📰 Notícias e Eventos")
+        st.write("Gere eventos aleatórios que afetam o mercado.")
+
+        if st.button("Gerar Evento"):
+            st.session_state["current_event"] = self.generate_event()
+
+        event = st.session_state.get("current_event")
+        if event:
+            st.markdown(f"**Evento:** {event.name}")
+            st.markdown(
+                f"Modificadores: Preço x{event.price_modifier}, "
+                f"Demanda x{event.demand_modifier}, "
+                f"Disponibilidade x{event.availability_modifier}"
+            )
+            st.markdown(f"Duração: {event.duration} dias")
+
+            with st.expander("Aplicar em valores de exemplo"):
+                price = st.number_input("Preço base", value=100.0)
+                demand = st.number_input("Demanda base", value=100.0)
+                availability = st.number_input("Disponibilidade base", value=100.0)
+                if st.button("Aplicar Modificadores"):
+                    result = self.apply_modifiers({
+                        "price": price,
+                        "demand": demand,
+                        "availability": availability,
+                    }, event)
+                    st.success(
+                        f"Preço: {result['price']:.2f} | "
+                        f"Demanda: {result['demand']:.2f} | "
+                        f"Disponibilidade: {result['availability']:.2f}"
+                    )

--- a/tests/test_news_mechanics.py
+++ b/tests/test_news_mechanics.py
@@ -1,0 +1,33 @@
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+st_dummy = types.ModuleType('streamlit')
+st_dummy.markdown = lambda *a, **k: None
+st_dummy.write = lambda *a, **k: None
+st_dummy.button = lambda *a, **k: False
+st_dummy.expander = lambda *a, **k: types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None)
+st_dummy.number_input = lambda *a, **k: 0
+st_dummy.success = lambda *a, **k: None
+st_dummy.session_state = {}
+sys.modules['streamlit'] = st_dummy
+
+from mechanics.news_mechanics import NewsMechanics, NewsEvent
+
+
+def test_generate_event_returns_known_event():
+    nm = NewsMechanics()
+    event = nm.generate_event()
+    assert isinstance(event, NewsEvent)
+    assert event in nm.events
+
+
+def test_apply_modifiers_calculates_values():
+    nm = NewsMechanics()
+    event = NewsEvent('Teste', 2.0, 0.5, 1.5, 1)
+    result = nm.apply_modifiers({'price': 10, 'demand': 20, 'availability': 30}, event)
+    assert result['price'] == 20
+    assert result['demand'] == 10
+    assert result['availability'] == 45


### PR DESCRIPTION
## Summary
- introduce `NewsMechanics` with random events
- show news mechanic tab in the Streamlit app
- test event generation and modifier application

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646982777083338755a6c964192642