### PR TITLE
Add election mechanics

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import streamlit as st
 
 from mechanics.calendar_mechanics import CalendarMechanics
 from mechanics.news_mechanics import NewsMechanics
+from mechanics.election_mechanics import ElectionMechanics
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -21,6 +22,7 @@ def main():
         "📅 Calendário",
         "💰 Mercado Financeiro",
         "📰 Eventos",
+        "🗳 Eleições",
         "🧪 Testes de Mesa",
         "📊 Comparação",
         "ℹ️ Sobre",
@@ -43,6 +45,10 @@ def main():
         st.title(selected_tab)
         news_mechanics = NewsMechanics()
         news_mechanics.run()
+    elif selected_tab == "🗳 Eleições":
+        st.title(selected_tab)
+        election_mechanics = ElectionMechanics()
+        election_mechanics.run()
     elif selected_tab == "🧪 Testes de Mesa":
         st.title(selected_tab)
         st.markdown("Este é um teste de conceito para testes de mesa.")

--- a/mechanics/election_mechanics.py
+++ b/mechanics/election_mechanics.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+import random
+import streamlit as st
+
+@dataclass
+class Candidate:
+    """Represent a political candidate with economic modifiers."""
+
+    name: str
+    tax_modifier: float = 1.0
+    regulation_modifier: float = 1.0
+    incentive_modifier: float = 1.0
+
+
+class ElectionMechanics:
+    """Simple election system with candidate modifiers."""
+
+    def __init__(self):
+        self.candidates = [
+            Candidate(
+                "Conservador",
+                tax_modifier=0.9,
+                regulation_modifier=0.8,
+                incentive_modifier=0.8,
+            ),
+            Candidate(
+                "Liberal",
+                tax_modifier=0.8,
+                regulation_modifier=0.6,
+                incentive_modifier=1.2,
+            ),
+            Candidate(
+                "Social",
+                tax_modifier=1.2,
+                regulation_modifier=1.1,
+                incentive_modifier=1.0,
+            ),
+        ]
+
+    def generate_candidate(self, name: str | None = None) -> Candidate:
+        """Return a random candidate or one by name."""
+        if name:
+            for candidate in self.candidates:
+                if candidate.name == name:
+                    return candidate
+        return random.choice(self.candidates)
+
+    def apply_modifiers(self, base_values: dict, candidate: Candidate) -> dict:
+        """Apply candidate modifiers to provided values."""
+        return {
+            "tax": base_values.get("tax", 0) * candidate.tax_modifier,
+            "regulation": base_values.get("regulation", 0)
+            * candidate.regulation_modifier,
+            "incentive": base_values.get("incentive", 0) * candidate.incentive_modifier,
+        }
+
+    def run(self):
+        """Display interface to generate and apply election modifiers."""
+        st.markdown("### 🗳 Eleições")
+        st.write("Simule o impacto de diferentes candidatos.")
+
+        if st.button("Sortear Candidato"):
+            st.session_state["current_candidate"] = self.generate_candidate()
+
+        candidate = st.session_state.get("current_candidate")
+        if candidate:
+            st.markdown(f"**Candidato:** {candidate.name}")
+            st.markdown(
+                f"Modificadores: Tributação x{candidate.tax_modifier}, "
+                f"Regulamentação x{candidate.regulation_modifier}, "
+                f"Incentivos x{candidate.incentive_modifier}"
+            )
+            with st.expander("Aplicar em valores de exemplo"):
+                tax = st.number_input("Tributação base", value=100.0)
+                regulation = st.number_input("Regulamentação base", value=100.0)
+                incentive = st.number_input("Incentivos base", value=100.0)
+                if st.button("Aplicar Modificadores"):
+                    result = self.apply_modifiers(
+                        {
+                            "tax": tax,
+                            "regulation": regulation,
+                            "incentive": incentive,
+                        },
+                        candidate,
+                    )
+                    st.success(
+                        f"Tributação: {result['tax']:.2f} | "
+                        f"Regulamentação: {result['regulation']:.2f} | "
+                        f"Incentivos: {result['incentive']:.2f}"
+                    )

--- a/tests/test_election_mechanics.py
+++ b/tests/test_election_mechanics.py
@@ -1,0 +1,33 @@
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+st_dummy = types.ModuleType('streamlit')
+st_dummy.markdown = lambda *a, **k: None
+st_dummy.write = lambda *a, **k: None
+st_dummy.button = lambda *a, **k: False
+st_dummy.expander = lambda *a, **k: types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None)
+st_dummy.number_input = lambda *a, **k: 0
+st_dummy.success = lambda *a, **k: None
+st_dummy.session_state = {}
+sys.modules['streamlit'] = st_dummy
+
+from mechanics.election_mechanics import ElectionMechanics, Candidate
+
+
+def test_generate_candidate_returns_known_candidate():
+    em = ElectionMechanics()
+    candidate = em.generate_candidate()
+    assert isinstance(candidate, Candidate)
+    assert candidate in em.candidates
+
+
+def test_apply_modifiers_calculates_values():
+    em = ElectionMechanics()
+    candidate = Candidate('Teste', 2.0, 0.5, 1.5)
+    result = em.apply_modifiers({'tax': 10, 'regulation': 20, 'incentive': 30}, candidate)
+    assert result['tax'] == 20
+    assert result['regulation'] == 10
+    assert result['incentive'] == 45


### PR DESCRIPTION
## Summary
- create `Candidate` dataclass and `ElectionMechanics` class
- expose new `🗳 Eleições` tab in `app.py`
- add basic tests for election mechanics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864779cc00c8333839c65ae7e3d993b