### PR TITLE
Add inflation mechanics with tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from mechanics.news_mechanics import NewsMechanics
 from mechanics.election_mechanics import ElectionMechanics
 from mechanics.currency_mechanics import CurrencyMechanics
 from mechanics.product_mechanics import ProductMechanics
+from mechanics.inflation_mechanics import InflationMechanics
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -24,6 +25,7 @@ def main():
         "📅 Calendário",
         "💰 Mercado Financeiro",
         "💱 Moedas",
+        "📈 Inflação",
         "📦 Produtos",
         "📰 Eventos",
         "🗳 Eleições",
@@ -49,6 +51,27 @@ def main():
         st.title(selected_tab)
         currency_mechanics = CurrencyMechanics()
         currency_mechanics.run()
+    elif selected_tab == "📈 Inflação":
+        st.title(selected_tab)
+        inflation_mechanics = InflationMechanics()
+        # Simple placeholder interface
+        st.markdown("### Índice de Inflação")
+        if "inflation_system" not in st.session_state:
+            st.session_state["inflation_system"] = inflation_mechanics
+        else:
+            inflation_mechanics = st.session_state["inflation_system"]
+
+        col1, col2 = st.columns(2)
+        with col1:
+            shock = st.checkbox("Choque de Oferta/Demanda (+3%)", key="shock")
+            promo = st.number_input("Promoção (-%)", min_value=0.0, max_value=0.5, value=0.0, step=0.01, key="promo")
+            if st.button("Avançar Dia"):
+                inflation_mechanics.advance_day(shock=shock, promotion_effect=promo)
+        with col2:
+            st.metric("Índice Atual", f"{inflation_mechanics.current_index:.3f}")
+            history = [rec.index for rec in inflation_mechanics.history]
+            if history:
+                st.line_chart(history)
     elif selected_tab == "📦 Produtos":
         st.title(selected_tab)
         product_mechanics = ProductMechanics()

--- a/mechanics/inflation_mechanics.py
+++ b/mechanics/inflation_mechanics.py
@@ -1,0 +1,49 @@
+# Simple inflation system for Retail Rush
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from Domain.Entity.Product import Product
+
+
+@dataclass
+class DailyRecord:
+    """Store daily inflation index history."""
+
+    day: int
+    index: float
+
+
+class InflationMechanics:
+    """Simulate continuous price variation over time."""
+
+    def __init__(self, base_weekly_rate: float = 0.005):
+        # Base weekly inflation rate (e.g. 0.5% -> 0.005)
+        self.base_weekly_rate = base_weekly_rate
+        self.current_index = 1.0
+        self.day_count = 0
+        self.history: List[DailyRecord] = []
+
+    def advance_day(self, shock: bool = False, promotion_effect: float = 0.0) -> float:
+        """Advance one day applying inflation, shocks and promotions."""
+        daily_rate = self.base_weekly_rate / 7
+        if shock:
+            daily_rate += 0.03  # abrupt 3% increase
+        daily_rate -= promotion_effect
+
+        self.current_index *= 1 + daily_rate
+        self.day_count += 1
+        self.history.append(DailyRecord(self.day_count, self.current_index))
+        return daily_rate
+
+    def apply_inflation(self, products: List[Product], shock: bool = False, promotion_effect: float = 0.0) -> None:
+        """Update product prices and costs based on today's inflation."""
+        daily_rate = self.advance_day(shock=shock, promotion_effect=promotion_effect)
+        for prod in products:
+            prod.cost *= 1 + daily_rate
+            prod.price *= 1 + daily_rate
+
+    def adjust_purchasing_power(self, income: float) -> float:
+        """Return income adjusted by accumulated inflation."""
+        return income / self.current_index

--- a/tests/test_inflation_mechanics.py
+++ b/tests/test_inflation_mechanics.py
@@ -1,0 +1,29 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from mechanics.inflation_mechanics import InflationMechanics
+from Domain.Entity.Product import Product
+
+
+def test_basic_inflation_growth():
+    im = InflationMechanics(base_weekly_rate=0.007)
+    p = Product("1", "Teste", "cat", "sup", 10.0, 20.0, "un")
+    for _ in range(7):
+        im.apply_inflation([p])
+    assert im.current_index > 1.0
+    assert p.price > 20.0
+
+
+def test_shock_increases_rate():
+    im = InflationMechanics()
+    p = Product("1", "Teste", "cat", "sup", 10.0, 20.0, "un")
+    im.apply_inflation([p], shock=True)
+    assert im.current_index > 1.03
+
+
+def test_promotion_reduces_rate():
+    im = InflationMechanics()
+    p = Product("1", "Teste", "cat", "sup", 10.0, 20.0, "un")
+    im.apply_inflation([p], promotion_effect=0.02)
+    assert im.current_index < 1.0


### PR DESCRIPTION
## Summary
- implement basic inflation simulation including shocks and promotions
- integrate inflation UI in the Streamlit app
- test new inflation mechanics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865209410c48333899e1ff00f22f57f