### PR TITLE
Integrate currency and inflation with products

### DIFF
--- a/mechanics/product_financial_system.py
+++ b/mechanics/product_financial_system.py
@@ -1,0 +1,15 @@
+class ProductFinanceSystem:
+    """Integrate inflation and currency mechanics with products."""
+
+    def __init__(self, inflation, currency, display_currency="Base"):
+        self.inflation = inflation
+        self.currency = currency
+        self.display_currency = display_currency
+
+    def advance_day(self, products, shock=False, promotion_effect=0.0):
+        """Advance one day applying inflation to given products."""
+        self.inflation.apply_inflation(products, shock=shock, promotion_effect=promotion_effect)
+
+    def product_price(self, product, from_currency="Base"):
+        """Return product price converted to the display currency."""
+        return self.currency.convert(product.price, from_currency, self.display_currency)

--- a/tests/test_product_financial_system.py
+++ b/tests/test_product_financial_system.py
@@ -1,0 +1,22 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from mechanics.product_financial_system import ProductFinanceSystem
+from mechanics.inflation_mechanics import InflationMechanics
+from mechanics.currency_mechanics import CurrencyMechanics
+from Domain.Entity.Product import Product
+
+
+def test_integration_price_update_and_conversion():
+    p = Product("1", "Teste", "cat", "sup", 10.0, 20.0, "un")
+    im = InflationMechanics(base_weekly_rate=0.007)
+    cm = CurrencyMechanics()
+    cm.add_currency('Dollar', '$', 5.0)
+    system = ProductFinanceSystem(im, cm, display_currency='Dollar')
+
+    system.advance_day([p])
+    price_in_dollar = system.product_price(p)
+    expected = cm.convert(p.price, 'Base', 'Dollar')
+    assert price_in_dollar == expected
+    assert p.price > 20.0


### PR DESCRIPTION
## Summary
- add `ProductFinanceSystem` to bridge product, currency, and inflation mechanics
- test integration of price updates and currency conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686523f7126c833380cee3ca37ac2613