### PR TITLE
Implement region mechanics

### DIFF
--- a/Domain/Entity/Map/region.py
+++ b/Domain/Entity/Map/region.py
@@ -1,4 +1,4 @@
-from random import random
+import random
 from Domain.Entity.Map.region_type import region_type
 
 
@@ -41,3 +41,4 @@ class Region:
             "Residential": region_type.Residential
         }
         return mapping.get(self.code, None)
+

--- a/Domain/Entity/Map/region_profile.py
+++ b/Domain/Entity/Map/region_profile.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class ElectionResult:
+    """Election vote percentages for two main candidates."""
+
+    candidate_a: float
+    candidate_b: float
+
+
+@dataclass
+class AgeDistribution:
+    """Population percentage by age groups."""
+
+    age_0_18: float
+    age_19_35: float
+    age_36_60: float
+    age_60_plus: float
+
+
+@dataclass
+class EthnicityDistribution:
+    """Population percentage by ethnicity."""
+
+    white: float
+    black: float
+    hispanic: float
+    asian: float
+    other: float
+
+
+@dataclass
+class RegionProfile:
+    """Detailed region information used for market simulations."""
+
+    name: str
+    currency: str
+    sales_tax: float
+    population: int
+    election: ElectionResult
+    age: AgeDistribution
+    ethnicity: EthnicityDistribution
+    climate: str
+    seasons: str
+    inflation_base: float
+    average_income: float
+    preferred_products: List[str] = field(default_factory=list)

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from mechanics.election_mechanics import ElectionMechanics
 from mechanics.currency_mechanics import CurrencyMechanics
 from mechanics.product_mechanics import ProductMechanics
 from mechanics.inflation_mechanics import InflationMechanics
+from mechanics.region_mechanics import RegionMechanics
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -29,6 +30,7 @@ def main():
         "📦 Produtos",
         "📰 Eventos",
         "🗳 Eleições",
+        "🌐 Regiões",
         "🧪 Testes de Mesa",
         "📊 Comparação",
         "ℹ️ Sobre",
@@ -84,6 +86,10 @@ def main():
         st.title(selected_tab)
         election_mechanics = ElectionMechanics()
         election_mechanics.run()
+    elif selected_tab == "🌐 Regiões":
+        st.title(selected_tab)
+        region_mechanics = RegionMechanics()
+        region_mechanics.run()
     elif selected_tab == "🧪 Testes de Mesa":
         st.title(selected_tab)
         st.markdown("Este é um teste de conceito para testes de mesa.")

--- a/mechanics/region_mechanics.py
+++ b/mechanics/region_mechanics.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import pandas as pd
+import streamlit as st
+
+from Domain.Entity.Map.region_profile import (
+    RegionProfile,
+    ElectionResult,
+    AgeDistribution,
+    EthnicityDistribution,
+)
+
+
+class RegionMechanics:
+    """Handle predefined region profiles for tabletop tests."""
+
+    def __init__(self):
+        self.regions = self._create_regions()
+
+    def _create_regions(self) -> dict[str, RegionProfile]:
+        """Return example region profiles for U.S. cities."""
+        return {
+            "NYC": RegionProfile(
+                name="New York City",
+                currency="USD",
+                sales_tax=0.08875,
+                population=8000000,
+                election=ElectionResult(candidate_a=60.0, candidate_b=40.0),
+                age=AgeDistribution(20.0, 30.0, 35.0, 15.0),
+                ethnicity=EthnicityDistribution(42.0, 24.0, 29.0, 14.0, 5.0),
+                climate="nublado",
+                seasons="invernos frios, verões quentes",
+                inflation_base=1.1,
+                average_income=65000,
+                preferred_products=["café quente", "guarda-chuva"],
+            ),
+            "LA": RegionProfile(
+                name="Los Angeles",
+                currency="USD",
+                sales_tax=0.095,
+                population=3900000,
+                election=ElectionResult(candidate_a=55.0, candidate_b=45.0),
+                age=AgeDistribution(23.0, 31.0, 33.0, 13.0),
+                ethnicity=EthnicityDistribution(29.0, 8.0, 49.0, 11.0, 3.0),
+                climate="ensolarado",
+                seasons="verões longos e secos",
+                inflation_base=1.0,
+                average_income=62000,
+                preferred_products=["sorvete", "óculos de sol"],
+            ),
+            "CHI": RegionProfile(
+                name="Chicago",
+                currency="USD",
+                sales_tax=0.1025,
+                population=2700000,
+                election=ElectionResult(candidate_a=58.0, candidate_b=42.0),
+                age=AgeDistribution(22.0, 29.0, 34.0, 15.0),
+                ethnicity=EthnicityDistribution(33.0, 29.0, 29.0, 7.0, 2.0),
+                climate="nevado",
+                seasons="invernos rigorosos, verões amenos",
+                inflation_base=1.2,
+                average_income=55000,
+                preferred_products=["chocolate quente", "agasalhos"],
+            ),
+        }
+
+    def run(self):
+        """Render a simple Streamlit UI to inspect regions."""
+        st.markdown("### 🌐 Sistema de Regiões")
+        st.write(
+            "Perfis geográficos que impactam demanda, preço e logística."
+        )
+        region_keys = list(self.regions.keys())
+        selection = st.selectbox(
+            "Escolha a região", [self.regions[k].name for k in region_keys]
+        )
+        region = next(r for r in self.regions.values() if r.name == selection)
+
+        with st.expander("Detalhes", expanded=True):
+            data = asdict(region)
+            df = (
+                pd.DataFrame(list(data.items()), columns=["Propriedade", "Valor"])
+                .astype(str)
+            )
+            st.dataframe(df, use_container_width=True)
+
+

--- a/tests/test_region_mechanics.py
+++ b/tests/test_region_mechanics.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Minimal streamlit stub
+import types
+st_dummy = types.ModuleType('streamlit')
+st_dummy.markdown = lambda *a, **k: None
+st_dummy.write = lambda *a, **k: None
+st_dummy.selectbox = lambda label, options: options[0]
+st_dummy.expander = lambda *a, **k: types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None)
+st_dummy.dataframe = lambda *a, **k: None
+sys.modules['streamlit'] = st_dummy
+
+import pandas as pd
+sys.modules['pandas'] = pd
+
+from mechanics.region_mechanics import RegionMechanics
+
+
+def test_regions_created():
+    rm = RegionMechanics()
+    assert set(rm.regions.keys()) == {"NYC", "LA", "CHI"}
+
+
+def test_election_sum_to_100():
+    rm = RegionMechanics()
+    for region in rm.regions.values():
+        total = region.election.candidate_a + region.election.candidate_b
+        assert abs(total - 100.0) < 0.001
+
+
+def test_climate_field():
+    rm = RegionMechanics()
+    allowed = {"ensolarado", "nublado", "nevado"}
+    for region in rm.regions.values():
+        assert region.climate in allowed
+


### PR DESCRIPTION
## Summary
- fix region module import for `random`
- add dataclasses describing detailed region profiles
- create `RegionMechanics` with example US city data
- integrate region interface into the Streamlit app
- test new region functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865274157988333b2b7ec872ba34555